### PR TITLE
Fixex worker counting (hopefully)

### DIFF
--- a/src/argument_processer.py
+++ b/src/argument_processer.py
@@ -9,4 +9,5 @@ def process_arguments(args: arguments.ConversionArguments):
     supported_formats = [".docx", ".doc", ".xls", ".xlsx"]
     args.input_paths = list(filter(lambda x: x.suffix in supported_formats, args.input_paths))
     args.input_paths.sort(key=lambda x: x.stat().st_size)  # Sort them according to filesize
+    args.proc_count = min(args.proc_count, len(args.input_paths))  # Don't make more workers than files to convert
     converter_manager.start_conversion(args)

--- a/src/unoserver_converter.py
+++ b/src/unoserver_converter.py
@@ -12,14 +12,13 @@ complete = None
 
 
 def unoserver_convert(args: arguments.ConversionArguments):
-    proc_count = min(args.proc_count, len(args.input_paths))  # Don't make more workers than files to convert
     cur_server_count = utils.get_process_count("unoserver")
-    for i in range(cur_server_count, proc_count):  # Create unoservers for parallelization,
+    for i in range(cur_server_count, args.proc_count):  # Create unoservers for parallelization,
         # if we don't have enough present already
         # This command creates a detached unoserver so that it doesn't shutdown when the script ends.
         os.system("nohup unoserver --port {} >/dev/null 2>&1 &".format(UNOSERVER_PORT + i))
     # We do not care about order, so we can use a pool of workers for conversion
-    pool = multiprocessing.Pool(processes=proc_count, initializer=unoserver_worker.initialize_converters)
+    pool = multiprocessing.Pool(processes=args.proc_count, initializer=unoserver_worker.initialize_converters)
     res = pool.starmap_async(unoserver_worker.convert_to_pdf, zip(args.input_paths, repeat(args.output_folder)),
                              chunksize=1, callback=complete)
     track_job(res)

--- a/src/unoserver_converter.py
+++ b/src/unoserver_converter.py
@@ -18,7 +18,8 @@ def unoserver_convert(args: arguments.ConversionArguments):
         # This command creates a detached unoserver so that it doesn't shutdown when the script ends.
         os.system("nohup unoserver --port {} >/dev/null 2>&1 &".format(UNOSERVER_PORT + i))
     # We do not care about order, so we can use a pool of workers for conversion
-    pool = multiprocessing.Pool(processes=args.proc_count, initializer=unoserver_worker.initialize_converters)
+    pool = multiprocessing.Pool(processes=args.proc_count,
+                                initializer=lambda: unoserver_worker.initialize_converters(args))
     res = pool.starmap_async(unoserver_worker.convert_to_pdf, zip(args.input_paths, repeat(args.output_folder)),
                              chunksize=1, callback=complete)
     track_job(res)

--- a/src/unoserver_worker.py
+++ b/src/unoserver_worker.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import unoserver.converter
 import unoserver_converter
 import converter_manager
+import time
 
 converter = None
 
@@ -10,13 +11,15 @@ converter = None
 def initialize_converters():
     # After the converter creates the workers, if the entire program hasn't stopped working (for example - web converter
     # then the ._identity[0] of the workers will keep going up and up, so we need to account for that.
-    worker_id = multiprocessing.current_process()._identity[0] - 1 - converter_manager.workers_created
+    #worker_id = multiprocessing.current_process()._identity[0] - 1 - converter_manager.workers_created
+    worker_id = 0
     global converter
+    time.sleep(1)
     while True:
         try:
             converter = unoserver.converter.UnoConverter("127.0.0.1", unoserver_converter.UNOSERVER_PORT + worker_id)
         except BaseException as err:
-            pass
+            raise err
         if converter is not None:
             break
 

--- a/src/unoserver_worker.py
+++ b/src/unoserver_worker.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import unoserver.converter
 import unoserver_converter
 import converter_manager
-import time
 
 converter = None
 
@@ -11,15 +10,13 @@ converter = None
 def initialize_converters():
     # After the converter creates the workers, if the entire program hasn't stopped working (for example - web converter
     # then the ._identity[0] of the workers will keep going up and up, so we need to account for that.
-    #worker_id = multiprocessing.current_process()._identity[0] - 1 - converter_manager.workers_created
-    worker_id = 0
+    worker_id = multiprocessing.current_process()._identity[0] - 1 - converter_manager.workers_created
     global converter
-    time.sleep(1)
     while True:
         try:
             converter = unoserver.converter.UnoConverter("127.0.0.1", unoserver_converter.UNOSERVER_PORT + worker_id)
         except BaseException as err:
-            raise err
+            pass
         if converter is not None:
             break
 

--- a/src/unoserver_worker.py
+++ b/src/unoserver_worker.py
@@ -2,7 +2,6 @@ import multiprocessing
 from pathlib import Path
 import unoserver.converter
 import unoserver_converter
-import converter_manager
 import arguments
 
 converter = None

--- a/src/unoserver_worker.py
+++ b/src/unoserver_worker.py
@@ -3,14 +3,15 @@ from pathlib import Path
 import unoserver.converter
 import unoserver_converter
 import converter_manager
+import arguments
 
 converter = None
 
 
-def initialize_converters():
+def initialize_converters(args: arguments.ConversionArguments):
     # After the converter creates the workers, if the entire program hasn't stopped working (for example - web converter
     # then the ._identity[0] of the workers will keep going up and up, so we need to account for that.
-    worker_id = multiprocessing.current_process()._identity[0] - 1 - converter_manager.workers_created
+    worker_id = (multiprocessing.current_process()._identity[0] - 1) % args.proc_count
     global converter
     while True:
         try:


### PR DESCRIPTION
Now worker_id will NEVER go under 0 or over the proc count, because it simply gets the mod of args.proc_count